### PR TITLE
Updated python-libnmap to v0.7.2

### DIFF
--- a/app/requirements.txt
+++ b/app/requirements.txt
@@ -1,5 +1,5 @@
 wheel==0.34.2
 Flask==1.1.2
 Werkzeug==1.0.1
-python-libnmap==0.7.0
+python-libnmap==0.7.2
 Flask-FontAwesome==0.1.4


### PR DESCRIPTION
Updated python-libnmap to v0.7.2 to fix security vulnerability in the package CVE-2019-1010017.
Note this vulnerability did not affect Observate.